### PR TITLE
0.4.0

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,12 +1,28 @@
 Netuitive Linux Agent Release History
 ===============================
 
+Version 0.4.0 - Jul 25 2016
+----------------------------
+- update netuitive-client-python to 0.2.0
+  - sanitize metric names
+- update to the latest netuitive diamond
+  - Fix/correct counter publishing
+- update netuitive-statsd to 0.2.0
+- update boto to 2.42.0
+- update cython to 0.24.1
+- update psycopg2 to 2.6.2
+- update pymongo to 3.3.0
+- update setuptools to 25.0.1
+- change git repo for Netuitive Diamond
+- address reinstall issue on deb based installs
+- add get-support script
+- add alpha version of netuitive-event-handler
+
 Version 0.3.2 - Jul 11 2016
 ----------------------------
 - update Netuitive Diamond
 - update netuitive-statsd to 0.1.1
     - fix tag processing bug
-
 
 Version 0.3.1 - Jun 30 2016
 ----------------------------

--- a/config/projects/netuitive-agent.rb
+++ b/config/projects/netuitive-agent.rb
@@ -7,7 +7,7 @@ homepage "http://www.netuitive.com"
 # and /opt/netuitive on all other platforms
 install_dir "#{default_root}/#{name}"
 
-build_version '0.3.2'
+build_version '0.4.0'
 build_iteration 1
 
 # Creates required build directories
@@ -19,6 +19,9 @@ dependency "netuitive-diamond"
 
 # netuitive statsd
 dependency "netuitive-statsd"
+
+# netuitive event handler
+dependency "netuitive-event-handler"
 
 # Version manifest file
 dependency "version-manifest"

--- a/config/software/netuitive-diamond.rb
+++ b/config/software/netuitive-diamond.rb
@@ -30,7 +30,7 @@ dependency "python-supervisor"
 # Sources may be URLs, git locations, or path locations
 #source git: "https://github.com/Netuitive/Diamond.git"
 #source path: "/vagrant/Diamond"
-source git: "https://github.com/Netuitive/Diamond.git"
+source git: "https://github.com/Netuitive/netuitive-diamond.git"
 
 # This is the path, inside the tarball, where the source resides
 relative_path "Diamond"
@@ -66,4 +66,7 @@ build do
 
     command "chmod 700 #{install_dir}/.install/scripts/*"
 
+    copy "#{install_dir}/.install/scripts/get-support", "#{install_dir}/bin/get-support"
+
 end
+

--- a/config/software/netuitive-event-handler.rb
+++ b/config/software/netuitive-event-handler.rb
@@ -1,0 +1,16 @@
+name "netuitive-event-handler"
+default_version "latest"
+
+# eventually this should be turned into a full git clone and build like the others
+
+source :url => "http://repos.app.netuitive.com/cli-agent/netuitive-event-handler-linux",
+       :md5 => '4adf233642325b04aff1955761d0917d'
+
+
+build do
+  # License
+  copy "netuitive-event-handler-linux", "#{install_dir}/bin/netuitive-event-handler"
+  command "chmod 0700 " \
+          "#{install_dir}/bin/netuitive-event-handler"
+end
+

--- a/config/software/python-boto.rb
+++ b/config/software/python-boto.rb
@@ -1,5 +1,5 @@
 name "boto"
-default_version "2.41.0"
+default_version "2.42.0"
 
 dependency "python"
 dependency "pip"

--- a/config/software/python-cython.rb
+++ b/config/software/python-cython.rb
@@ -1,5 +1,5 @@
 name "cython"
-default_version "0.24"
+default_version "0.24.1"
 
 dependency "python"
 dependency "pip"

--- a/config/software/python-psycopg2.rb
+++ b/config/software/python-psycopg2.rb
@@ -1,5 +1,5 @@
 name "psycopg2"
-default_version "2.6.1"
+default_version "2.6.2"
 
 dependency "python"
 dependency "pip"

--- a/config/software/python-pymongo.rb
+++ b/config/software/python-pymongo.rb
@@ -1,5 +1,5 @@
 name "pymongo"
-default_version "3.2.2"
+default_version "3.3.0"
 
 dependency "python"
 dependency "pip"

--- a/config/software/setuptools.rb
+++ b/config/software/setuptools.rb
@@ -19,7 +19,7 @@ default_version "25.0.1"
 
 dependency "python"
 
-source url: "https://pypi.python.org/packages/f0/21/708b3eb6709ece3cb2613b6c44e749823c435bef0b26b9b45be1634afe16/setuptools-#{version}tar.gz",
+source url: "https://pypi.python.org/packages/f0/21/708b3eb6709ece3cb2613b6c44e749823c435bef0b26b9b45be1634afe16/setuptools-#{version}.tar.gz",
        md5: '0177aa36b2d59b030bd628db1e6a0072'
 
 relative_path "setuptools-#{version}"

--- a/config/software/setuptools.rb
+++ b/config/software/setuptools.rb
@@ -15,12 +15,12 @@
 #
 
 name "setuptools"
-default_version "23.1.0"
+default_version "25.0.1"
 
 dependency "python"
 
-source url: "https://pypi.python.org/packages/9f/7c/0a33c528164f1b7ff8cf0684cf88c2e733c8ae0119ceca4a3955c7fc059d/setuptools-#{version}.tar.gz",
-       md5: 'f7f447663f7d5e17c84be10dc6b195fd'
+source url: "https://pypi.python.org/packages/f0/21/708b3eb6709ece3cb2613b6c44e749823c435bef0b26b9b45be1634afe16/setuptools-#{{version}}tar.gz",
+       md5: '0177aa36b2d59b030bd628db1e6a0072'
 
 relative_path "setuptools-#{version}"
 

--- a/config/software/setuptools.rb
+++ b/config/software/setuptools.rb
@@ -19,7 +19,7 @@ default_version "25.0.1"
 
 dependency "python"
 
-source url: "https://pypi.python.org/packages/f0/21/708b3eb6709ece3cb2613b6c44e749823c435bef0b26b9b45be1634afe16/setuptools-#{{version}}tar.gz",
+source url: "https://pypi.python.org/packages/f0/21/708b3eb6709ece3cb2613b6c44e749823c435bef0b26b9b45be1634afe16/setuptools-#{version}tar.gz",
        md5: '0177aa36b2d59b030bd628db1e6a0072'
 
 relative_path "setuptools-#{version}"

--- a/netuitive/scripts/get-support
+++ b/netuitive/scripts/get-support
@@ -1,0 +1,197 @@
+#!/opt/netuitive-agent/embedded/bin/python
+# coding=utf-8
+
+import os
+import platform
+import psutil
+import re
+import logging
+import datetime
+import json
+import zipfile
+import shutil
+import socket
+
+try:
+    import netuitive
+except ImportError:
+    netuitive = None
+
+try:
+    import docker
+except ImportError:
+    docker = None
+
+
+def zipdir(path, ziph):
+    # ziph is zipfile handle
+    for root, dirs, files in os.walk(path):
+        for file in files:
+            ziph.write(os.path.join(root, file))
+
+
+def get_human_readable_size(num, suffix='B'):
+    for unit in ['', 'K', 'M', 'G', 'T', 'P', 'E', 'Z']:
+        if abs(num) < 1024.0:
+            return(("%3.2f %s%s" % (num, unit, suffix)).strip())
+        num /= 1024.0
+    return(("%.2f %s%s" % (num, 'Y', suffix)).strip())
+
+
+def check_lsb():
+
+    if os.path.isfile("/etc/lsb-release"):
+        try:
+            _distributor_id_file_re = re.compile(
+                "(?:DISTRIB_ID\s*=)\s*(.*)", re.I)
+            _release_file_re = re.compile(
+                "(?:DISTRIB_RELEASE\s*=)\s*(.*)", re.I)
+            _codename_file_re = re.compile(
+                "(?:DISTRIB_CODENAME\s*=)\s*(.*)", re.I)
+            with open("/etc/lsb-release", "rU") as etclsbrel:
+                for line in etclsbrel:
+                    m = _distributor_id_file_re.search(line)
+                    if m:
+                        _u_distname = m.group(1).strip()
+                    m = _release_file_re.search(line)
+                    if m:
+                        _u_version = m.group(1).strip()
+                    m = _codename_file_re.search(line)
+                    if m:
+                        _u_id = m.group(1).strip()
+                if _u_distname and _u_version:
+                    return (_u_distname, _u_version, _u_id)
+        except Exception as e:
+            logging.debug(e)
+            return(None)
+
+    else:
+        return(None)
+
+
+def _get_version():
+    """
+    Return version string
+    """
+
+    if os.path.isfile('/opt/netuitive-agent/version-manifest.txt'):
+        with open('/opt/netuitive-agent/version-manifest.txt', 'r') as f:
+            v = f.readline()
+
+        f.close()
+
+        ret = v.replace(' ', '_').lower().rstrip()
+
+    return(ret)
+
+
+def _add_sys_meta():
+    try:
+
+        ret = {}
+        ret['platform'] = platform.system()
+        ret['agent'] = _get_version()
+
+        if psutil:
+            ret['cpus'] = psutil.cpu_count()
+
+            mem = psutil.virtual_memory()
+
+            ret[
+                'ram'] = get_human_readable_size(mem.total)
+            ret['ram bytes'] = mem.total
+            ret[
+                'boottime'] = str(datetime.datetime.fromtimestamp(psutil.boot_time()))
+
+        if platform.system().startswith('Linux'):
+            if check_lsb() is None:
+                supported_dists = platform._supported_dists + ('system',)
+                dist = platform.linux_distribution(
+                    supported_dists=supported_dists)
+
+            else:
+                dist = check_lsb()
+
+            ret['distribution_name'] = str(dist[0])
+            ret[
+                'distribution_version'] = str(dist[1])
+            if dist[2] != '':
+                ret['distribution_id'] = str(dist[2])
+
+        return(ret)
+
+    except Exception as e:
+        logging.debug(e)
+        pass
+
+
+def _add_docker_meta():
+    ret = "not_installed"
+    if docker:
+        try:
+
+            ret = {}
+            cc = docker.Client(
+                base_url='unix://var/run/docker.sock', version='auto')
+            dockerver = cc.version()
+
+            for k, v in dockerver.items():
+
+                if type(v) is list:
+                    vl = ', '.join(v)
+                    v = vl
+                ret['docker_' + k] = v
+
+        except Exception as e:
+            logging.debug(e)
+            pass
+
+    return(ret)
+
+if __name__ == "__main__":
+
+    print('\nCollecting logs and configuration....\n')
+
+    timestamp = str(datetime.datetime.now().strftime("%Y%m%d_%H%M%S"))
+    supportzip = '/opt/netuitive-agent/support-' + timestamp + '.zip'
+
+    data = {}
+    data['support_timestamp'] = timestamp
+    data['hostname'] = socket.gethostname()
+    data['metadata'] = _add_sys_meta()
+    data['docker'] = _add_docker_meta()
+
+    if os.path.exists('/opt/netuitive-agent/support'):
+        shutil.rmtree('/opt/netuitive-agent/support/')
+
+    if not os.path.exists('/opt/netuitive-agent/support'):
+        os.makedirs('/opt/netuitive-agent/support')
+
+    with open('/opt/netuitive-agent/support/metadata.json', 'w') as f:
+        f.write(json.dumps(data, indent=4))
+
+    f.close()
+
+    shutil.copy('/opt/netuitive-agent/version-manifest.txt',
+                '/opt/netuitive-agent/support/version-manifest.txt')
+
+    shutil.copy('/opt/netuitive-agent/version-manifest.json',
+                '/opt/netuitive-agent/support/version-manifest.json')
+
+    shutil.copytree('/opt/netuitive-agent/conf/',
+                    '/opt/netuitive-agent/support/conf')
+
+    shutil.copytree('/opt/netuitive-agent/log/',
+                    '/opt/netuitive-agent/support/log')
+
+    print('creating zip file....\n')
+    zipf = zipfile.ZipFile(supportzip,
+                           'w', zipfile.ZIP_DEFLATED)
+    zipdir('/opt/netuitive-agent/support/', zipf)
+    zipf.close()
+
+    shutil.rmtree('/opt/netuitive-agent/support/')
+
+    print('Please open a support case with and upload {0}'.format(supportzip))
+    print('with a detailed description of the issue.\n')
+    print('Thank you\n')

--- a/package-scripts/netuitive-agent/postinst
+++ b/package-scripts/netuitive-agent/postinst
@@ -36,6 +36,17 @@ cleanup_old_files()
 
 }
 
+failsafe_conf_file()
+{
+  if [ ! -f "/opt/netuitive-agent/conf/netuitive-agent.conf" ]; then
+    cp /opt/netuitive-agent/.install/conf/netuitive-agent.conf /opt/netuitive-agent/conf/netuitive-agent.conf
+  fi
+
+  if [ ! -f "/opt/netuitive-agent/conf/supervisor.conf" ]; then
+    cp /opt/netuitive-agent/.install/conf/supervisor.conf /opt/netuitive-agent/conf/supervisor.conf
+  fi
+}
+
 upgrade_scripts()
 {
   /opt/netuitive-agent/.install/scripts/upgrade
@@ -95,6 +106,7 @@ init_scripts()
     # /sbin/service netuitive-agent start
 
   fi
+
 }
 
 case "$1" in
@@ -105,16 +117,10 @@ case "$1" in
     exit 0
     ;;
 
-  configure)
+  *)
     # Looks like a DEB install. We don't know if it is a fresh install or an
     # upgrade.
-    if [ -z $2 ]; then
-      init_scripts
-      upgrade_scripts
-    fi
-    ;;
 
-  *)
     if [ -x /bin/rpm ] ; then
         init_scripts
         upgrade_scripts
@@ -123,6 +129,7 @@ case "$1" in
 esac
 
 cleanup_old_files
+failsafe_conf_file
 print_welcome
 
 exit 0

--- a/package-scripts/netuitive-agent/postinst
+++ b/package-scripts/netuitive-agent/postinst
@@ -114,7 +114,15 @@ case "$1" in
     # Looks like an RPM upgrade
     init_scripts
     upgrade_scripts
-    exit 0
+    failsafe_conf_file
+    ;;
+
+  configure)
+    # Looks like a DEB install. We don't know if it is a fresh install or an
+    # upgrade.
+    init_scripts
+    upgrade_scripts
+    failsafe_conf_file
     ;;
 
   *)
@@ -124,12 +132,12 @@ case "$1" in
     if [ -x /bin/rpm ] ; then
         init_scripts
         upgrade_scripts
+        failsafe_conf_file
     fi
     ;;
 esac
 
 cleanup_old_files
-failsafe_conf_file
 print_welcome
 
 exit 0

--- a/package-scripts/netuitive-agent/postrm
+++ b/package-scripts/netuitive-agent/postrm
@@ -12,7 +12,9 @@ notify()
 cleanup () {
 
   if [ -f "/usr/lib/systemd/system/netuitive-agent.service" ]; then
-    /bin/systemctl disenable netuitive-agent.service
+    /bin/systemctl disenable netuitive-agent.service > /dev/null 2>&1
+    /bin/systemctl disable netuitive-agent.service > /dev/null 2>&1
+
     rm -f /usr/lib/systemd/system/netuitive-agent.service
     /bin/systemctl daemon-reload
   fi


### PR DESCRIPTION
Version 0.4.0 - Jul 25 2016
----------------------------
- update netuitive-client-python to 0.2.0
  - sanitize metric names
- update to the latest netuitive diamond
  - Fix/correct counter publishing
- update netuitive-statsd to 0.2.0
- update boto to 2.42.0
- update cython to 0.24.1
- update psycopg2 to 2.6.2
- update pymongo to 3.3.0
- update setuptools to 25.0.1
- change git repo for Netuitive Diamond
- address reinstall issue on deb based installs
- add get-support script
- add alpha version of netuitive-event-handler
