### PR TITLE
Feature reduce more metrics

### DIFF
--- a/netuitive/conf/collectors/CassandraJolokiaCollector.conf
+++ b/netuitive/conf/collectors/CassandraJolokiaCollector.conf
@@ -1,6 +1,7 @@
 enabled = False
 host = localhost
 port = 8778
-path = jolokia
+path = cassandra
+jolokia_path = jolokia
 mbeans = org.apache.cassandra.metrics
-metrics_blacklist=.*Histogram\..*|.*Percentile$|.*\.Min$|.*\.Max$|.*\.Mean$|.*\.Count$|.*\.StdDev$|.*\.MeanRate$|.*\.FiveMinuteRate$|.*\.FifteenMinuteRate$
+metrics_blacklist=.*Histogram\..*|.*Percentile$|.*\.Min$|.*\.Max$|.*\.Mean$|.*\.Count$|.*\.StdDev$|.*\.MeanRate$|.*\.FiveMinuteRate$|.*\.FifteenMinuteRate$.*\.Keyspaces\.system.*$

--- a/netuitive/conf/collectors/CassandraJolokiaCollector.conf
+++ b/netuitive/conf/collectors/CassandraJolokiaCollector.conf
@@ -2,3 +2,5 @@ enabled = False
 host = localhost
 port = 8778
 path = jolokia
+mbeans = org.apache.cassandra.metrics
+metrics_blacklist=.*Histogram\..*|.*Percentile$|.*\.Min$|.*\.Max$|.*\.Mean$|.*\.Count$|.*\.StdDev$|.*\.MeanRate$|.*\.FiveMinuteRate$|.*\.FifteenMinuteRate$

--- a/netuitive/conf/collectors/ElasticSearchCollector.conf
+++ b/netuitive/conf/collectors/ElasticSearchCollector.conf
@@ -1,0 +1,4 @@
+enabled = True
+logstash_mode = True
+cluster = True
+metrics_blacklist=elasticsearch\.indices\.(?!_all$|datastore$|docs$)


### PR DESCRIPTION
Changed "path" parameter to "cassandra" since that gets prepended to the metric name. Added "jolokia_path=jolokia" (needed to do this since path no longer points to jolokia). Added "mbeans" parameter to only collect from "org.apache.cassandra.metrics". Added "metrics_blacklist" parameter to limit the number of collected metrics.