### PR TITLE
Update netuitive-agent.conf

### DIFF
--- a/netuitive/conf/netuitive-agent.conf
+++ b/netuitive/conf/netuitive-agent.conf
@@ -143,6 +143,7 @@ simple = True
 
 [[DiskUsageCollector]]
 enabled = True
+devices = (?:PhysicalDrive[0-9]+$|md[0-9]+$|sd[a-z]+[0-9]*$|x?vd[a-z]+[0-9]*$|disk[0-9]+$)
 metrics_whitelist = (?:^.*\.io$|^.*\.average_queue_length$|^.*\.await$|^.*\.iops$|^.*\.read_await$|^.*\.reads$|^.*\.util_percentage|^.*\.write_await$|^.*\.writes$)
 
 [[LoadAverageCollector]]


### PR DESCRIPTION
Adds a devices config entry to the DiskUsageCollector to remove dm devices.
