### PR TITLE
New default Jolokia config will: 1) only collect from Java MBeans; an…

### DIFF
--- a/netuitive/conf/collectors/JolokiaCollector.conf
+++ b/netuitive/conf/collectors/JolokiaCollector.conf
@@ -1,4 +1,7 @@
 enabled = False
 host = localhost
 port = 8778
-path = jolokia
+path = jmx
+jolokia_path = jolokia
+mbeans = java.*
+regex = true


### PR DESCRIPTION
…d 2) put all metrics under "jmx." rather than "jolokia."