### PR TITLE
fix elastic search blacklist regex

### DIFF
--- a/netuitive/conf/collectors/ElasticSearchCollector.conf
+++ b/netuitive/conf/collectors/ElasticSearchCollector.conf
@@ -1,4 +1,4 @@
 enabled = False
 logstash_mode = True
 cluster = True
-metrics_blacklist = elasticsearch\.indices\.(?=_all|\.).*
+metrics_blacklist = elasticsearch\.indices\.(?!_all\.|datastore\.|docs\.).*

--- a/netuitive/conf/collectors/ElasticSearchCollector.conf
+++ b/netuitive/conf/collectors/ElasticSearchCollector.conf
@@ -1,4 +1,4 @@
 enabled = False
 logstash_mode = True
 cluster = True
-metrics_blacklist = elasticsearch\.indices\.(?!_all$|datastore$|docs$)
+metrics_blacklist = elasticsearch\.indices\.(?=_all|\.).*

--- a/netuitive/conf/collectors/ElasticSearchCollector.conf
+++ b/netuitive/conf/collectors/ElasticSearchCollector.conf
@@ -1,4 +1,4 @@
 enabled = False
 logstash_mode = True
 cluster = True
-metrics_blacklist = elasticsearch\.indices\.(?!_all\.|datastore\.|docs\.).*
+metrics_blacklist = ^indices\.(?!_all\.|datastore\.|docs\.).*


### PR DESCRIPTION
this should filter out _all and system indices that start with ".", e.g. ".monitoring" and ".kibana" 