### PR TITLE
Update RabbitMQCollector.conf

### DIFF
--- a/netuitive/conf/collectors/RabbitMQCollector.conf
+++ b/netuitive/conf/collectors/RabbitMQCollector.conf
@@ -4,4 +4,4 @@ user = guest
 password = guest
 replace_dot = '_'
 cluster = True
-metrics_blacklist = "(.*-test__[abc]-.*)|(rabbitmq\.queues\..*)"
+metrics_blacklist = "(.*-test__[abc]-.*)|(^queues.*)"


### PR DESCRIPTION
Exclude all individual queue metrics by default