### PR TITLE
Fixing a trivial typo in netuitive-agent.conf

### DIFF
--- a/netuitive/conf/netuitive-agent.conf
+++ b/netuitive/conf/netuitive-agent.conf
@@ -94,7 +94,7 @@ enabled = False
 ### Defaults options for all Collectors
 
 # Uncomment and set to hardcode a hostname for the collector path
-# Keep in mind, periods are seperators in graphite
+# Keep in mind, periods are separators in graphite
 # hostname = my_custom_hostname
 
 # If you prefer to just use a different way of calculating the hostname


### PR DESCRIPTION
Separators is only spelled with one e.