### PR TITLE
Fixes #84 - Broken SNMP Collector

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,9 @@
 Netuitive Linux Agent Release History
 ===============================
+Version next
+----------------------------
+- Update pysnmp to 4.4.4
+
 Version 0.6.6
 ----------------------------
 - update python to 2.7.15

--- a/config/software/python-pysnmp.rb
+++ b/config/software/python-pysnmp.rb
@@ -1,5 +1,5 @@
 name "pysnmp"
-default_version "4.3.2"
+default_version "4.4.4"
 
 dependency "python"
 dependency "pip"


### PR DESCRIPTION
Bumping pysnmp library version up to the latest to fix the SNMP Collector.