### PR TITLE
Bugfix/bzip2 source

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -3,16 +3,12 @@ Netuitive Linux Agent Release History
 Version next
 ----------------------------
 
-<<<<<<< HEAD
 Version 0.7.1
 ----------------------------
 - Fix ElasticSearchCollector ssl config options type error
 
 Version 0.7.0
 ----------------------------
-=======
-Version 0.7.0
->>>>>>> e8f79b199ad740b09eb2554b94bcce5e9c9db8e2
 - Add a SimpleCollector config (off by default)
 - Add minimal mode (off by default) option to the NetuitiveDockerCollector
 - Enable BaseCollector by default, per #80

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2,6 +2,8 @@ Netuitive Linux Agent Release History
 ===============================
 Version next
 ----------------------------
+- Update cacerts.rb
+- Change bzip2 source to fix broken build dependency 
 
 Version 0.7.3
 ----------------------------

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2,12 +2,12 @@ Netuitive Linux Agent Release History
 ===============================
 Version next
 ----------------------------
-- Added help content for port and process check collectors
 
 Version 0.6.2
 ----------------------------
-- fix netuitive-statsd poster which caches elements forever
-- fix remapping of the PuppetDB queue metrics for PuppetDB 5.1
+- Fix netuitive-statsd poster which caches elements forever
+- Fix remapping of the PuppetDB queue metrics for PuppetDB 5.1
+- Add help content for port and process check collectors
 
 Version 0.6.1
 ----------------------------

--- a/config/projects/netuitive-agent.rb
+++ b/config/projects/netuitive-agent.rb
@@ -7,11 +7,7 @@ homepage 'http://www.netuitive.com'
 # and /opt/netuitive on all other platforms
 install_dir "#{default_root}/#{name}"
 
-<<<<<<< HEAD
 build_version '0.7.1'
-=======
-build_version '0.7.0'
->>>>>>> e8f79b199ad740b09eb2554b94bcce5e9c9db8e2
 build_iteration 1
 
 # Creates required build directories

--- a/config/projects/netuitive-agent.rb
+++ b/config/projects/netuitive-agent.rb
@@ -7,7 +7,7 @@ homepage "http://www.netuitive.com"
 # and /opt/netuitive on all other platforms
 install_dir "#{default_root}/#{name}"
 
-build_version '0.6.2-RC1'
+build_version '0.6.2'
 build_iteration 1
 
 # Creates required build directories

--- a/config/software/bzip2.rb
+++ b/config/software/bzip2.rb
@@ -23,7 +23,8 @@ default_version "1.0.6"
 dependency "zlib"
 dependency "openssl"
 
-source url: "http://www.bzip.org/#{version}/#{name}-#{version}.tar.gz",
+#source url: "http://www.bzip.org/#{version}/#{name}-#{version}.tar.gz",
+source url: "https://fossies.org/linux/misc/#{name}-#{version}.tar.gz",
        md5: "00b516f4704d4a7cb50a1d97e6e8e15b"
 
 relative_path "#{name}-#{version}"

--- a/config/software/cacerts.rb
+++ b/config/software/cacerts.rb
@@ -17,10 +17,10 @@
 name "cacerts"
 
 # Date of the file is in a comment at the start, or in the changelog
-default_version "2017.01.18"
+default_version "2018.10.17"
 
-version "2017.01.18" do
-  source md5: "38cd779c9429ab6e2e5ae3437b763238"
+version "2018.10.17" do
+  source md5: "882db4f54c25b5157cef6c0d182e729e"
 end
 
 


### PR DESCRIPTION
Fixes #94 Broken bzip2 link and updates cacerts to current.