### PR TITLE
Provide pkg concurrent-log-handler

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -5,6 +5,7 @@ Version next
 - Exclude device mapper virtual drives from DiskSpaceCollector by default
 - Add a default TCPCollector config
 - Add ConsulCollector.conf to project config
+- Add pkg concurrent-log-handler to fix locking, I/O errors when multiprocess logging to single file
 
 Version 0.7.4
 ----------------------------

--- a/config/software/concurrent-log-handler.rb
+++ b/config/software/concurrent-log-handler.rb
@@ -1,0 +1,26 @@
+#
+# Copyright:: Copyright (c) 2013-2014 Chef Software, Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name "concurrent-log-handler"
+default_version "0.9.12"
+
+dependency "python"
+dependency "pip"
+
+build do
+	command "#{install_dir}/embedded/bin/pip install -I -t #{install_dir}/embedded/lib/python2.7 concurrent-log-handler"
+end

--- a/config/software/netuitive-diamond.rb
+++ b/config/software/netuitive-diamond.rb
@@ -1,5 +1,5 @@
 name "netuitive-diamond"
-default_version "master"
+default_version "bugfix/concurrentlog"
 
 dependency "postgresql"
 dependency "mysql-client"
@@ -10,8 +10,8 @@ dependency "python-psutil"
 dependency "python-setproctitle"
 
 
-
 # Handlers dependency
+dependency "concurrent-log-handler"
 dependency "python-netuitive"
 dependency "python-statsd"
 # Collectors dependency

--- a/config/software/netuitive-diamond.rb
+++ b/config/software/netuitive-diamond.rb
@@ -1,5 +1,5 @@
 name "netuitive-diamond"
-default_version "bugfix/concurrentlog"
+default_version "master"
 
 dependency "postgresql"
 dependency "mysql-client"


### PR DESCRIPTION
This is the 1st of 3 PR's addressing https://github.com/Netuitive/netuitive-diamond/issues/63 
Because of changes across the omnibus and netuitive-diamond repos for the proposed solution, staggered changes are necessary to prevent breakage during build tests.

The concurrent-log-handler differs from our current implementation of TimedRotatingFileHandler by using file locking (provided by portalocker).  This allows multiple processes to safely log to the same file.