### PR TITLE
Better examples in DNSLookupCheckCollector conf file

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2,6 +2,7 @@ Netuitive Linux Agent Release History
 ===============================
 Version next
 ----------------------------
+- Provide better examples in DNSLookupCheckCollector.conf file
 
 Version 0.7.6
 ----------------------------

--- a/netuitive/conf/collectors/DNSLookupCheckCollector.conf
+++ b/netuitive/conf/collectors/DNSLookupCheckCollector.conf
@@ -1,3 +1,3 @@
 enabled = False
 ttl = 150
-dnsAddressList = host01.example.com, host02.example.com
+dnsAddressList = host01.example.com, example.com

--- a/netuitive/conf/collectors/DNSLookupCheckCollector.conf
+++ b/netuitive/conf/collectors/DNSLookupCheckCollector.conf
@@ -1,5 +1,3 @@
 enabled = False
 ttl = 150
-
-#Replace www.google.com and www.yahoo.com with the DNS names you want to check
-dnsAddressList = www.google.com, www.yahoo.com
+dnsAddressList = host01.example.com, host02.example.com


### PR DESCRIPTION
Notation and formatting is apparent enough that a commented section telling you what to replace isn't necessary.