### PR TITLE
Upgrade ruby version to 2.5.1

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -3,6 +3,8 @@ Netuitive Linux Agent Release History
 Version next
 ----------------------------
 
+- Upgrade ruby version to 2.5.1
+
 Version 0.7.7
 ----------------------------
 - Provide better examples in DNSLookupCheckCollector.conf file

--- a/build/Dockerfile.deb
+++ b/build/Dockerfile.deb
@@ -28,7 +28,7 @@ RUN gpg2 --keyserver hkp://keys.gnupg.net --recv-keys 409B6B1796C275462A17031138
  && curl -sSL https://get.rvm.io | bash -s stable
 
 COPY Gemfile /tmp
-RUN /bin/bash -l -c "rvm use --install 2.3.1; gem install bundler --no-ri --no-rdoc; cd /tmp; bundle config timeout 30; bundle install --verbose --binstubs --jobs `nproc --ignore=1` --retry=3"
+RUN /bin/bash -l -c "rvm use --install 2.5.1; gem install bundler --no-ri --no-rdoc; cd /tmp; bundle config timeout 30; bundle install --verbose --binstubs --jobs `nproc --ignore=1` --retry=3"
 
 VOLUME ["/vagrant"]
 CMD ["/bin/bash","/vagrant/build/build_agent.sh"]

--- a/build/Dockerfile.rpm
+++ b/build/Dockerfile.rpm
@@ -25,7 +25,7 @@ RUN gpg2 --keyserver hkp://keys.gnupg.net --recv-keys 409B6B1796C275462A17031138
  && curl -sSL https://get.rvm.io | bash -s stable
 
 COPY Gemfile /tmp
-RUN /bin/bash -l -c "rvm use --install 2.3.1; gem install bundler --no-ri --no-rdoc; cd /tmp; bundle config timeout 30; bundle install --verbose --binstubs --jobs `nproc --ignore=1` --retry=3"
+RUN /bin/bash -l -c "rvm use --install 2.5.1; gem install bundler --no-ri --no-rdoc; cd /tmp; bundle config timeout 30; bundle install --verbose --binstubs --jobs `nproc --ignore=1` --retry=3"
 
 VOLUME ["/vagrant"]
 CMD ["/bin/bash","/vagrant/build/build_agent.sh"]

--- a/build/build_agent.sh
+++ b/build/build_agent.sh
@@ -7,7 +7,7 @@
 # curl -sSL https://get.rvm.io | bash -s stable
 
 # source /etc/profile.d/rvm.sh
-# rvm use --install 2.3.1
+# rvm use --install 2.5.1
 # gem install --verbose bundler
 
 if [ -f "/usr/bin/yum" ]; then
@@ -23,7 +23,7 @@ cp -rf /vagrant /var/cache/omnibus
 cd /var/cache/omnibus
 
 source /etc/profile.d/rvm.sh
-rvm use --install 2.3.1
+rvm use --install 2.5.1
 bundle config timeout 30
 bundle install --verbose --binstubs --jobs `nproc --ignore=1` --retry=3
 


### PR DESCRIPTION
A dependent gem, mixlib-cli, dropped support for versions of ruby older than 2.5.