### PR TITLE
Replace wheezy source with jessie

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2,6 +2,7 @@ Netuitive Linux Agent Release History
 ===============================
 Version next
 ----------------------------
+- Replace wheezy source with jessie for debian7 testing
 
 Version 0.7.7-RC2
 ----------------------------

--- a/build/Dockerfile.deb
+++ b/build/Dockerfile.deb
@@ -5,6 +5,10 @@
 
 FROM      debian:7
 
+RUN sed -i '/wheezy/d' /etc/apt/sources.list \
+ && echo "deb http://deb.debian.org/debian jessie main" >> /etc/apt/sources.list \
+ && echo "deb http://security.debian.org/debian-security jessie/updates main" >> /etc/apt/sources.list
+
 RUN apt-get update \
  && apt-get install -y build-essential \
  && apt-get install -y gnupg2 \


### PR DESCRIPTION
Wheezy's end of life was announced last year. All repo contents have been moved from wheezy to jessie as of earlier this year. Apt cannot be updated with its source pointed at the old wheezy location, so it needs to be pointed at the jessie location instead.