### PR TITLE
Removing the `--no-ri` and `--no-rdoc` option from gem install bundle…

### DIFF
--- a/build/Dockerfile.deb
+++ b/build/Dockerfile.deb
@@ -32,7 +32,7 @@ RUN gpg2 --keyserver hkp://keys.gnupg.net --recv-keys 409B6B1796C275462A17031138
  && curl -sSL https://get.rvm.io | bash -s stable
 
 COPY Gemfile /tmp
-RUN /bin/bash -l -c "rvm use --install 2.5.1; gem install bundler --no-ri --no-rdoc; cd /tmp; bundle config timeout 30; bundle install --verbose --binstubs --jobs `nproc --ignore=1` --retry=3"
+RUN /bin/bash -l -c "rvm use --install 2.5.1 && gem install bundler && cd /tmp && bundle config timeout 30 && bundle install --verbose --binstubs --jobs `nproc --ignore=1` --retry=3"
 
 VOLUME ["/vagrant"]
 CMD ["/bin/bash","/vagrant/build/build_agent.sh"]

--- a/build/Dockerfile.rpm
+++ b/build/Dockerfile.rpm
@@ -25,7 +25,7 @@ RUN gpg2 --keyserver hkp://keys.gnupg.net --recv-keys 409B6B1796C275462A17031138
  && curl -sSL https://get.rvm.io | bash -s stable
 
 COPY Gemfile /tmp
-RUN /bin/bash -l -c "rvm use --install 2.5.1; gem install bundler --no-ri --no-rdoc; cd /tmp; bundle config timeout 30; bundle install --verbose --binstubs --jobs `nproc --ignore=1` --retry=3"
+RUN /bin/bash -l -c "rvm use --install 2.5.1 && gem install bundler && cd /tmp && bundle config timeout 30 && bundle install --verbose --binstubs --jobs `nproc --ignore=1` --retry=3"
 
 VOLUME ["/vagrant"]
 CMD ["/bin/bash","/vagrant/build/build_agent.sh"]


### PR DESCRIPTION
…r. Also change `;` to `&&` so the subsequent commands have exit 0 before continuing