### PR TITLE
Improvement tests

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2,6 +2,9 @@ Netuitive Linux Agent Release History
 ===============================
 Version next
 ----------------------------
+- Debian7 dockerfile added to address apt-get broken repo mirrors
+- test.sh global sleep bumped to 5 minutes (the tests actually stop the docker container, there is no need to die unless the test is not running or exits with error and without cleanup)
+- runtest.sh has been consolidated into a run block. we can now scale tests by adding them to the RELEASE var
 
 Version 0.7.8
 ----------------------------

--- a/testing/docker/Dockerfile.debian7
+++ b/testing/docker/Dockerfile.debian7
@@ -1,0 +1,17 @@
+FROM debian:7
+
+ENV container docker
+ENV LC_ALL C
+ENV DEBIAN_FRONTEND noninteractive
+
+RUN sed -i '/wheezy/d' /etc/apt/sources.list \
+ && echo "deb http://deb.debian.org/debian jessie main" >> /etc/apt/sources.list \
+ && echo "deb http://security.debian.org/debian-security jessie/updates main" >> /etc/apt/sources.list
+
+# Install packages
+RUN apt-get -y update \
+    && apt-get -y install \
+    curl python sudo
+
+VOLUME ["/vagrant"]
+CMD ["/bin/bash","/vagrant/docker/test.sh"]

--- a/testing/docker/test.sh
+++ b/testing/docker/test.sh
@@ -30,6 +30,7 @@ elif [ `hostname` == "debian7" ]; then
     for f in /vagrant/dist/*.deb; do dpkg -i $f; done
     cat /vagrant/test.conf > /opt/netuitive-agent/conf/netuitive-agent.conf
     service netuitive-agent start
+    sleep 120
 
 elif [ `hostname` == "debian8" ]; then
     apt-get update

--- a/testing/docker/test.sh
+++ b/testing/docker/test.sh
@@ -30,7 +30,6 @@ elif [ `hostname` == "debian7" ]; then
     for f in /vagrant/dist/*.deb; do dpkg -i $f; done
     cat /vagrant/test.conf > /opt/netuitive-agent/conf/netuitive-agent.conf
     service netuitive-agent start
-    sleep 120
 
 elif [ `hostname` == "debian8" ]; then
     apt-get update
@@ -81,4 +80,4 @@ else
 fi
 
 
-sleep 65
+sleep 300

--- a/testing/runtest.sh
+++ b/testing/runtest.sh
@@ -5,84 +5,65 @@ if [ -z "$1" ]; then
     exit 1
 fi
 
-if [ "$1" == "centos6" ] ||  [ "$1" == "all" ]; then
-    echo "Running centos6 test..."
-    time docker run --rm --name centos6-test -v `pwd`:/vagrant -h centos6 centos:6 /vagrant/docker/test.sh
+RELEASE="centos6 centos7 debian7 debian8 ubuntu12 ubuntu14 ubuntu15 ubuntu16"
+
+runtest() {
+    echo "Running ${OS} test..."
+
+    if [ -f "docker/Dockerfile.${OS}" ]; then
+        image="local/${OS}"
+
+        echo "Building docker image: ${image}"
+        docker build --rm -t ${image} -f docker/Dockerfile.${OS} .
+
+        echo "Creating docker container: ${OS}-test"
+        docker create --rm --privileged --name ${OS}-test -h ${OS} ${image}
+
+        echo "Copying local to ${OS}-test:/vagrant"
+        docker cp . ${OS}-test:/vagrant/
+
+        echo "Starting container: ${OS}-test"
+        time docker start ${OS}-test 
+    else
+        image=`echo "${OS}" | sed 's%\([0-9]\)%:\1%'`
+
+        echo "Creating docker container: ${OS}-test"
+        docker create --rm --privileged --name ${OS}-test -h ${OS} ${image} /vagrant/docker/test.sh
+
+        echo "Copying local to ${OS}-test:/vagrant"
+        docker cp . ${OS}-test:/vagrant/
+
+        echo "Starting container: ${OS}-test"
+        time docker start ${OS}-test
+    fi
+
     sleep 120
-    docker stop centos6-test
-    docker rm centos6-test
-    docker rmi centos:6
-fi
+    docker cp ${OS}-test:/vagrant/${OS}-testserver.log .
+    
+    docker stop ${OS}-test || echo "${OS}-test: stopped"
+    docker rmi -f ${image} || echo "${image}: removed"
 
-if [ "$1" == "centos7" ] ||  [ "$1" == "all" ]; then
-    echo "Running centos7 test..."
-    docker build --rm -t local/c7-systemd-test -f docker/Dockerfile.centos7 .
-    time docker run --privileged -d --name centos7-test -v `pwd`:/vagrant -h centos7 local/c7-systemd-test
-    sleep 120
-    docker stop centos7-test
-    docker rm centos7-test
-    docker rmi local/c7-systemd-test
-fi
-
-if [ "$1" == "debian7" ] ||  [ "$1" == "all" ]; then
-    echo "Running debian7 test..."
-    time docker run --rm --name debian7-test -v `pwd`:/vagrant -h debian7 debian:7 /vagrant/docker/test.sh
-    sleep 120
-    docker stop debian7-test
-    docker rm debian7-test
-    docker rmi -f debian:7
-fi
-
-if [ "$1" == "debian8" ] ||  [ "$1" == "all" ]; then
-    echo "Running debian8 test..."
-    docker build -t local/d8-systemd-test -f docker/Dockerfile.debian8 .
-    time docker run --privileged -d --name debian8-test -v `pwd`:/vagrant -h debian8 local/d8-systemd-test
-    sleep 120
-    docker stop debian8-test
-    docker rm debian8-test
-    docker rmi local/d8-systemd-test
-fi
+    grep -e '\.*' *.log
+}
 
 
-if [ "$1" == "ubuntu12" ] ||  [ "$1" == "all" ]; then
-    echo "Running ubuntu12 test..."
-    docker build --rm -t local/u12-upstart-test -f docker/Dockerfile.ubuntu12 .
-    docker run -d --name ubuntu12-test -v `pwd`:/vagrant -h ubuntu12 local/u12-upstart-test&
-    sleep 120
-    docker stop ubuntu12-test
-    docker rm ubuntu12-test
-    docker rmi local/u12-upstart-test
-fi
+case $1 in
+        all)
+            for OS in $RELEASE; do
+                runtest
+            done
+            ;;
+        *)
+            if [[ "${RELEASE}" == *"${1}"* ]]; then
+                OS=${1}
+                runtest
+            else
+                echo "Please choose from one of the following:"
+                echo "['$RELEASE all']" | sed "s% %', '%g"
+                exit 0
+            fi
+            ;;
+esac
 
-if [ "$1" == "ubuntu14" ] ||  [ "$1" == "all" ]; then
-    echo "Running ubuntu14 test..."
-    docker build --rm -t local/u14-upstart-test -f docker/Dockerfile.ubuntu14 .
-    docker run --rm --name ubuntu14-test -v `pwd`:/vagrant -h ubuntu14 local/u14-upstart-test&
-    sleep 120
-    docker stop ubuntu14-test
-    docker rm ubuntu14-test
-    docker rmi local/u14-upstart-test
-fi
 
-if [ "$1" == "ubuntu15" ] ||  [ "$1" == "all" ]; then
-    echo "Running ubuntu15 test..."
-    docker build --rm -t local/u15-systemd-test -f docker/Dockerfile.ubuntu15 .
-    time docker run --privileged -d --name ubuntu15-test -v `pwd`:/vagrant -h ubuntu15 local/u15-systemd-test
-    sleep 120
-    docker stop ubuntu15-test
-    docker rm ubuntu15-test
-    docker rmi local/u15-systemd-test
-fi
-
-if [ "$1" == "ubuntu16" ] ||  [ "$1" == "all" ]; then
-    echo "Running ubuntu16 test..."
-    docker build --rm -t local/u16-systemd-test -f docker/Dockerfile.ubuntu16 .
-    time docker run --privileged -d --name ubuntu16-test -v `pwd`:/vagrant -h ubuntu16 local/u16-systemd-test
-    sleep 120
-    docker stop ubuntu16-test
-    docker rm ubuntu16-test
-    docker rmi local/u16-systemd-test
-fi
-
-grep -e '\.*' *.log
 

--- a/testing/runtest.sh
+++ b/testing/runtest.sh
@@ -38,7 +38,8 @@ runtest() {
     fi
 
     sleep 120
-    docker cp ${OS}-test:/vagrant/${OS}-testserver.log .
+    docker cp ${OS}-test:/vagrant/ .
+    
     
     docker stop ${OS}-test || echo "${OS}-test: stopped"
     docker rmi -f ${image} || echo "${image}: removed"

--- a/testing/runtest.sh
+++ b/testing/runtest.sh
@@ -38,7 +38,9 @@ runtest() {
     fi
 
     sleep 120
-    docker cp ${OS}-test:/vagrant/ .
+    docker cp ${OS}-test:/vagrant/${OS}-testserver.log .
+    docker cp ${OS}-test:/vagrant/${OS}.log .
+    docker cp ${OS}-test:/vagrant/${OS}.pass .
     
     
     docker stop ${OS}-test || echo "${OS}-test: stopped"


### PR DESCRIPTION
Lots of updates on this PR

* Debian7 dockerfile added to address apt-get repo broken mirrors
* test.sh global sleep bumped to 5 minutes (the tests actually stop the docker container, there is no need to die unless the test is not running or exits with error and without cleanup)
* runtest.sh has been consolidated into a run block. we can now scale tests by adding them to the RELEASE var